### PR TITLE
refactor: remove unused replace import

### DIFF
--- a/Swarky
+++ b/Swarky
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 import sys, re, time, shutil, logging
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Dict, Any


### PR DESCRIPTION
## Summary
- remove unused replace import from dataclasses

## Testing
- `flake8 Swarky` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `python -m py_compile Swarky`


------
https://chatgpt.com/codex/tasks/task_e_68a73169a8648332afe22aad9683e517