### PR TITLE
Remove redundant run-once flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Swarky
+
+CLI per l'archiviazione e la generazione di file EDI.
+
+## Utilizzo
+
+Esegui una passata singola (archivio + ISS + FIV):
+
+```bash
+python Swarky
+```
+
+Esegui in modalità watch con un intervallo in secondi:
+
+```bash
+python Swarky --watch 60
+```
+
+Opzioni disponibili:
+
+- `--config PATH` – Percorso file di configurazione TOML
+- `--watch SECONDS` – Loop di polling in secondi, `0` esegue una sola passata
+- `--debug` – Abilita logging dettagliato

--- a/Swarky
+++ b/Swarky
@@ -310,8 +310,7 @@ def parse_args(argv: List[str]):
     import argparse
     ap = argparse.ArgumentParser(description="Swarky - batch archiviazione/EDI")
     ap.add_argument("--config", type=str, default="config.toml", help="Percorso file di configurazione TOML")
-    ap.add_argument("--run-once", action="store_true", help="Esegue una passata (archivio + ISS + FIV)")
-    ap.add_argument("--watch", type=int, default=0, help="Loop di polling in secondi, 0=disattivato")
+    ap.add_argument("--watch", type=int, default=0, help="Loop di polling in secondi, 0=esegue una sola passata")
     ap.add_argument("--debug", action="store_true", help="Abilita logging DEBUG")
     return ap.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- drop unused `--run-once` CLI flag
- clarify `--watch` help text and document usage

## Testing
- `python -m py_compile Swarky`
- `python Swarky --help`


------
https://chatgpt.com/codex/tasks/task_e_68a73352d5408332a927fa66a947b527