### PR TITLE
Handle orientation errors and log failures

### DIFF
--- a/Swarky
+++ b/Swarky
@@ -153,10 +153,16 @@ def uom_from_letter(ch: str) -> str:
 def check_orientation_ok(tif_path: Path) -> bool:
     try:
         from PIL import Image  # opzionale
+    except ImportError:
+        logging.warning("PIL non installato, impossibile verificare l'orientamento di %s", tif_path)
+        return True
+
+    try:
         with Image.open(tif_path) as im:
             return im.width > im.height
     except Exception:
-        return True
+        logging.exception("Errore durante la verifica dell'orientamento per %s", tif_path)
+        return False
 
 # ---- LOG WRITERS ---------------------------------------------------------------------
 

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import sys
+import types
+import builtins
+import logging
+
+import importlib.util
+import importlib.machinery
+
+
+def load_swarky():
+    module_path = Path(__file__).resolve().parents[1] / "Swarky"
+    loader = importlib.machinery.SourceFileLoader("swarky", str(module_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+def test_check_orientation_ok_import_error(monkeypatch, caplog):
+    swarky = load_swarky()
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "PIL", raising=False)
+    monkeypatch.delitem(sys.modules, "PIL.Image", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        result = swarky.check_orientation_ok(Path("dummy.tif"))
+
+    assert result is True
+    assert "PIL non installato" in caplog.text
+
+
+def test_check_orientation_ok_logs_error(monkeypatch, caplog):
+    swarky = load_swarky()
+
+    dummy = types.ModuleType("PIL")
+
+    class DummyImageModule:
+        @staticmethod
+        def open(_):
+            raise RuntimeError("boom")
+
+    dummy.Image = DummyImageModule
+    monkeypatch.setitem(sys.modules, "PIL", dummy)
+
+    with caplog.at_level(logging.ERROR):
+        result = swarky.check_orientation_ok(Path("dummy.tif"))
+
+    assert result is False
+    assert "Errore durante la verifica" in caplog.text


### PR DESCRIPTION
## Summary
- Log warning when PIL is missing and orientation can't be checked
- Log and fail orientation check on other image errors
- Add tests covering warning and error logging for orientation checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73b97b6dc8332b338268ba7e830c9