### PR TITLE
Use dictionary for location mapping and add tests

### DIFF
--- a/Swarky
+++ b/Swarky
@@ -125,21 +125,32 @@ def write_lines(p: Path, lines: List[str]):
 
 # ---- MAPPATURE E VALIDAZIONI ---------------------------------------------------------
 
+LOCATION_MAP = {
+    ("M", "*"): ("costruttivi", "Costruttivi", "m", "DETAIL", "Italian"),
+    ("K", "*"): ("bozzetti", "Bozzetti", "k", "Customer Drawings", "English"),
+    ("F", "*"): ("fornitori", "Fornitori", "f", "Vendor Supplied Data", "English"),
+    ("T", "*"): ("tenute_meccaniche", "T_meccaniche", "t", "Customer Drawings", "English"),
+    ("E", "*"): ("sezioni", "Sezioni", "s", "Customer Drawings", "English"),
+    ("S", "*"): ("sezioni", "Sezioni", "s", "Customer Drawings", "English"),
+    ("N", "*"): ("marcianise", "Marcianise", "n", "DETAIL", "Italian"),
+    ("P", "*"): ("preventivi", "Preventivi", "p", "Customer Drawings", "English"),
+    ("*", "4"): ("pID_ELETTRICI", "Pid_Elettrici", "m", "Customer Drawings", "Italian"),
+    ("*", "5"): ("piping", "Piping", "m", "Customer Drawings", "Italian"),
+}
+
+DEFAULT_LOCATION = ("unknown", "Unknown", "m", "Customer Drawings", "English")
+
+
 def map_location(m: re.Match, cfg: Config) -> dict:
     first = m.group(3)[0]
     l2 = m.group(2).upper()
-    out = {}
-    if l2 == "M" and first not in ("4","5"): out = ("costruttivi","Costruttivi","m","DETAIL","Italian")
-    elif l2 == "K": out = ("bozzetti","Bozzetti","k","Customer Drawings","English")
-    elif l2 == "F": out = ("fornitori","Fornitori","f","Vendor Supplied Data","English")
-    elif l2 == "T": out = ("tenute_meccaniche","T_meccaniche","t","Customer Drawings","English")
-    elif l2 in ("E","S"): out = ("sezioni","Sezioni","s","Customer Drawings","English")
-    elif l2 == "N": out = ("marcianise","Marcianise","n","DETAIL","Italian")
-    elif l2 == "P": out = ("preventivi","Preventivi","p","Customer Drawings","English")
-    elif first == "4": out = ("pID_ELETTRICI","Pid_Elettrici","m","Customer Drawings","Italian")
-    elif first == "5": out = ("piping","Piping","m","Customer Drawings","Italian")
-    else: out = ("unknown","Unknown","m","Customer Drawings","English")
-    folder, log_name, subloc, doctype, lang = out
+    loc = (
+        LOCATION_MAP.get((l2, first))
+        or LOCATION_MAP.get((l2, "*"))
+        or LOCATION_MAP.get(("*", first))
+        or DEFAULT_LOCATION
+    )
+    folder, log_name, subloc, doctype, lang = loc
     arch_tif_loc = m.group(1).upper() + subloc
     dir_tif_loc = cfg.ARCHIVIO_DISEGNI / folder / arch_tif_loc
     return dict(folder=folder, log_name=log_name, subloc=subloc, doctype=doctype, lang=lang, arch_tif_loc=arch_tif_loc, dir_tif_loc=dir_tif_loc)

--- a/tests/test_map_location.py
+++ b/tests/test_map_location.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import importlib.util
+import importlib.machinery
+import sys
+import pytest
+
+
+def load_swarky():
+    module_path = Path(__file__).resolve().parents[1] / "Swarky"
+    loader = importlib.machinery.SourceFileLoader("swarky", str(module_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def swarky():
+    return load_swarky()
+
+
+@pytest.fixture
+def cfg(swarky, tmp_path):
+    return swarky.Config(
+        DIR_HPLOTTER=tmp_path / "hplotter",
+        ARCHIVIO_DISEGNI=tmp_path / "archivio",
+        ERROR_DIR=tmp_path / "error",
+        PARI_REV_DIR=tmp_path / "pari_rev",
+        PLM_DIR=tmp_path / "plm",
+        ARCHIVIO_STORICO=tmp_path / "storico",
+        DIR_ISS=tmp_path / "iss",
+        DIR_FIV_LOADING=tmp_path / "fiv",
+        DIR_HENGELO=tmp_path / "hengelo",
+        DIR_KALT=tmp_path / "kalt",
+        DIR_KALT_ERRORS=tmp_path / "kalt_err",
+        DIR_TABELLARI=tmp_path / "tab",
+    )
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("DAM123456R01S01A.tif", "costruttivi"),
+        ("DAK123456R01S01A.tif", "bozzetti"),
+        ("DAF123456R01S01A.tif", "fornitori"),
+        ("DAT123456R01S01A.tif", "tenute_meccaniche"),
+        ("DAE123456R01S01A.tif", "sezioni"),
+        ("DAS123456R01S01A.tif", "sezioni"),
+        ("DAN123456R01S01A.tif", "marcianise"),
+        ("DAP123456R01S01A.tif", "preventivi"),
+        ("DAX412345R01S01A.tif", "pID_ELETTRICI"),
+        ("DAX512345R01S01A.tif", "piping"),
+        ("DAX712345R01S01A.tif", "unknown"),
+    ],
+)
+def test_map_location(swarky, cfg, name, expected):
+    m = swarky.BASE_NAME.match(name)
+    loc = swarky.map_location(m, cfg)
+    assert loc["folder"] == expected


### PR DESCRIPTION
## Summary
- replace if/elif chain with dictionary keyed by second letter and first digit
- handle unknown combinations with a default mapping
- add comprehensive tests for `map_location`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73ba11c40833283c45bdd0c128ed8