### PR TITLE
Remove dynamic config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,4 @@ python Swarky --watch 60
 
 Opzioni disponibili:
 
-- `--config PATH` – Percorso file di configurazione TOML
 - `--watch SECONDS` – Loop di polling in secondi, `0` esegue una sola passata

--- a/Swarky
+++ b/Swarky
@@ -326,7 +326,6 @@ def watch_loop(cfg: Config, interval: int):
 def parse_args(argv: List[str]):
     import argparse
     ap = argparse.ArgumentParser(description="Swarky - batch archiviazione/EDI")
-    ap.add_argument("--config", type=str, default="config.toml", help="Percorso file di configurazione TOML")
     ap.add_argument("--watch", type=int, default=0, help="Loop di polling in secondi, 0=esegue una sola passata")
     return ap.parse_args(argv)
 
@@ -338,8 +337,7 @@ def load_config(path: Path) -> Config:
 
 def main(argv: List[str]):
     args = parse_args(argv)
-    cfg_path = Path(args.config)
-    cfg = load_config(cfg_path)
+    cfg = load_config(Path("config.toml"))
     setup_logging(cfg)
     if args.watch > 0:
         watch_loop(cfg, args.watch)


### PR DESCRIPTION
## Summary
- remove CLI option for providing config file path
- assume config.toml in working directory and update README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac15b875748332bcb5ba416d4a4325