### PR TITLE
Use console output for run_once counts

### DIFF
--- a/Swarky
+++ b/Swarky
@@ -314,7 +314,7 @@ def count_tif_files(cfg: Config) -> dict:
 
 def run_once(cfg: Config):
     archive_once(cfg); iss_loading(cfg); fiv_loading(cfg)
-    logging.info("Counts: %s", count_tif_files(cfg))
+    print("Counts:", count_tif_files(cfg))
 
 def watch_loop(cfg: Config, interval: int):
     logging.info("Watch ogni %ds...", interval)


### PR DESCRIPTION
## Summary
- Replace logging counts in `run_once` with a concise console print

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac17aec78c8332a1965d22befb44ee