### PR TITLE
Track file processing in archive_once

### DIFF
--- a/Swarky
+++ b/Swarky
@@ -210,10 +210,12 @@ def write_edi(cfg: Config, m: re.Match, file_name: str, loc: dict, hyd: bool, ou
 
 # ---- PIPELINE PRINCIPALE -------------------------------------------------------------
 
-def archive_once(cfg: Config):
+def archive_once(cfg: Config) -> bool:
     start = time.time()
     normalize_extensions(cfg.DIR_HPLOTTER)
+    did_something = False
     for p in sorted(cfg.DIR_HPLOTTER.glob("*.tif")):
+        did_something = True
         hyd = False
         q = process_h_tif(p)
         if q: p, hyd = q, True
@@ -262,8 +264,10 @@ def archive_once(cfg: Config):
         move_to(p, dir_tif_loc)
         write_edi(cfg, m, p.name, loc, hyd, cfg.PLM_DIR)
 
-    elapsed = time.time() - start
-    write_lines((cfg.LOG_DIR or cfg.DIR_HPLOTTER)/f"Swarky_{datetime.now().strftime('%b.%Y')}.log", [f"ProcessTime # {elapsed:.2f}s"])
+    if did_something:
+        elapsed = time.time() - start
+        write_lines((cfg.LOG_DIR or cfg.DIR_HPLOTTER)/f"Swarky_{datetime.now().strftime('%b.%Y')}.log", [f"ProcessTime # {elapsed:.2f}s"])
+    return did_something
 
 def iss_loading(cfg: Config):
     for p in sorted(cfg.DIR_ISS.glob("*.pdf")):

--- a/tests/test_archive_once.py
+++ b/tests/test_archive_once.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import importlib.util
+import importlib.machinery
+import sys
+import pytest
+
+
+def load_swarky():
+    module_path = Path(__file__).resolve().parents[1] / "Swarky"
+    loader = importlib.machinery.SourceFileLoader("swarky", str(module_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def swarky():
+    return load_swarky()
+
+
+@pytest.fixture
+def cfg(swarky, tmp_path):
+    return swarky.Config(
+        DIR_HPLOTTER=tmp_path / "hplotter",
+        ARCHIVIO_DISEGNI=tmp_path / "archivio",
+        ERROR_DIR=tmp_path / "error",
+        PARI_REV_DIR=tmp_path / "pari_rev",
+        PLM_DIR=tmp_path / "plm",
+        ARCHIVIO_STORICO=tmp_path / "storico",
+        DIR_ISS=tmp_path / "iss",
+        DIR_FIV_LOADING=tmp_path / "fiv",
+        DIR_HENGELO=tmp_path / "hengelo",
+        DIR_KALT=tmp_path / "kalt",
+        DIR_KALT_ERRORS=tmp_path / "kalt_err",
+        DIR_TABELLARI=tmp_path / "tab",
+        LOG_DIR=tmp_path / "logs",
+    )
+
+
+def log_path(swarky, cfg):
+    return cfg.LOG_DIR / f"Swarky_{swarky.month_tag()}.log"
+
+
+def test_archive_once_logs_process_time(swarky, cfg, monkeypatch):
+    cfg.DIR_HPLOTTER.mkdir()
+    (cfg.DIR_HPLOTTER / "DAM123456R01S01A.tif").write_bytes(b"0")
+    monkeypatch.setattr(swarky, "check_orientation_ok", lambda _: True)
+    assert swarky.archive_once(cfg) is True
+    assert "ProcessTime" in log_path(swarky, cfg).read_text(encoding="utf-8")
+
+
+def test_archive_once_skips_process_time_if_no_files(swarky, cfg):
+    cfg.DIR_HPLOTTER.mkdir()
+    assert swarky.archive_once(cfg) is False
+    assert not log_path(swarky, cfg).exists()


### PR DESCRIPTION
## Summary
- Detect whether archive_once processed or moved any files
- Only log `ProcessTime` when work is performed
- Add tests for conditional logging behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac183a870c83328d6d450174dbf2ef