### PR TITLE
Make grid column headers black

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -37,7 +37,7 @@ style.configure(
     foreground="white",
     fieldbackground="navy",
 )
-style.configure("Treeview.Heading", background="navy", foreground="white")
+style.configure("Treeview.Heading", background="white", foreground="black")
 root.title("Swarky")
 
 root.columnconfigure(0, weight=1)


### PR DESCRIPTION
## Summary
- Make column headers use black text on white background for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac78732a88833283c6aa486e683638