### PR TITLE
Colora i bordi dei box in navy

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -29,7 +29,9 @@ for font_name in ("TkDefaultFont", "TkTextFont", "TkMenuFont", "TkHeadingFont"):
     except tk.TclError:
         pass
 style = ttk.Style(root)
+style.theme_use("clam")
 style.configure(".", font=("Calibri", 11))
+style.configure("TLabelframe", bordercolor="navy")
 # Imposta lo sfondo e il colore del testo per le treeview
 style.configure(
     "Treeview",


### PR DESCRIPTION
## Summary
- Imposta il tema `clam` e definisce il colore dei bordi dei `LabelFrame` in navy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7aa433ac8332ab79168d045c5c46