### PR TITLE
Adatta larghezza box disegni al nome file

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -101,7 +101,10 @@ def refresh_plotter():
         for p in cfg.DIR_HPLOTTER.glob(pat)
         if p.is_file()
     }
-    for name in sorted(files.values(), key=str.lower):
+    names = sorted(files.values(), key=str.lower)
+    max_len = max((len(n) for n in names), default=0)
+    plotter_list.config(width=max_len)
+    for name in names:
         plotter_list.insert(tk.END, name)
 
 


### PR DESCRIPTION
## Summary
- adatta la larghezza della lista dei disegni in base alla lunghezza del nome file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7bac498083329f87281488525af6