### PR TITLE
Use Consolas for GUI fonts

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -155,13 +155,13 @@ class SwarkyApp:
     def _setup_theme(self) -> None:
         for fname in ("TkDefaultFont","TkTextFont","TkMenuFont","TkHeadingFont"):
             try:
-                tkfont.nametofont(fname).configure(family="Calibri")
+                tkfont.nametofont(fname).configure(family="Consolas")
             except tk.TclError:
                 pass
         style = ttk.Style(self.root)
         try: style.theme_use("clam")
         except tk.TclError: pass
-        style.configure(".", font=("Calibri", 11), background=LIGHT_BG, foreground=FG_DARK)
+        style.configure(".", font=("Consolas", 11), background=LIGHT_BG, foreground=FG_DARK)
         style.configure("TFrame", background=LIGHT_BG)
         style.configure("TLabelframe", background=LIGHT_BG, bordercolor=NAVY_BG)
         style.configure("TLabelframe.Label", background=LIGHT_BG, foreground=FG_DARK)


### PR DESCRIPTION
## Summary
- switch Tkinter default fonts to Consolas

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e847ff988332b900299fa183179f